### PR TITLE
Added the option to install FiraCode font during run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   - TEST_VAR="js_homebrewcask_sublimetext3_enabled=True"
   - TEST_VAR="js_homebrewcask_atom_enabled=True"
   - TEST_VAR="js_homebrewcask_visualstudiocode_enabled=True"
+  - TEST_VAR="js_homebrewcask_fontfiracode_enabled=True"
   - TEST_VAR="js_homebrewcask_gpgsuite_enabled=True"
   - TEST_VAR="js_homebrewcask_slack_enabled=True"
   - TEST_VAR="js_homebrewcask_discord_enabled=True"

--- a/global_vars/no_vars.yml
+++ b/global_vars/no_vars.yml
@@ -9,6 +9,7 @@ js_homebrewcask_iterm2_enabled: False
 js_homebrewcask_sublimetext3_enabled: False
 js_homebrewcask_atom_enabled: False
 js_homebrewcask_visualstudiocode_enabled: False
+js_homebrewcask_fontfiracode_enabled: False
 js_homebrewcask_gpgsuite_enabled: False
 js_homebrewcask_googlechrome_enabled: False
 js_homebrewcask_slack_enabled: False

--- a/global_vars/vars.yml
+++ b/global_vars/vars.yml
@@ -10,6 +10,7 @@ js_homebrewcask_iterm2_enabled: True
 js_homebrewcask_sublimetext3_enabled: True
 js_homebrewcask_atom_enabled: True
 js_homebrewcask_visualstudiocode_enabled: True
+js_homebrewcask_fontfiracode_enabled: True
 js_homebrewcask_gpgsuite_enabled: True
 js_homebrewcask_googlechrome_enabled: True
 js_homebrewcask_slack_enabled: True

--- a/playbooks/configure.yml
+++ b/playbooks/configure.yml
@@ -53,6 +53,10 @@
       prompt: "Would you like to install Visual Studio Code?"
       default: "yes"
       private: no
+    - name: js_homebrewcask_fontfiracode_enabled
+      prompt: "Would you like to install FiraCode font?"
+      default: "yes"
+      private: no
     - name: js_homebrewcask_gpgsuite_enabled
       prompt: "Would you like to install GPG Suite?"
       default: "yes"
@@ -119,6 +123,10 @@
         path: "../global_vars/vars.yml"
         regexp: "^js_homebrewcask_visualstudiocode_enabled: (?:True|False)$"
         line: "js_homebrewcask_visualstudiocode_enabled: {{ js_homebrewcask_visualstudiocode_enabled|bool }}"
+    - lineinfile:
+        path: "../global_vars/vars.yml"
+        regexp: "^js_homebrewcask_fontfiracode_enabled: (?:True|False)$"
+        line: "js_homebrewcask_fontfiracode_enabled: {{ js_homebrewcask_fontfiracode_enabled|bool }}"
     - lineinfile:
         path: "../global_vars/vars.yml"
         regexp: "^js_homebrewcask_gpgsuite_enabled: (?:True|False)$"

--- a/playbooks/roles/brew-cask/tasks/fontfiracode.yml
+++ b/playbooks/roles/brew-cask/tasks/fontfiracode.yml
@@ -4,6 +4,6 @@
     name: homebrew/cask-fonts
     state: present
 
-- name: Install Firacode font through Homebrew
+- name: Install the Firacode font through Homebrew
   homebrew_cask:
     name: font-fira-code

--- a/playbooks/roles/brew-cask/tasks/fontfiracode.yml
+++ b/playbooks/roles/brew-cask/tasks/fontfiracode.yml
@@ -1,0 +1,9 @@
+---
+- name: Tap the homebrew cask-fonts repository
+  homebrew_tap: 
+    name: homebrew/cask-fonts
+    state: present
+
+- name: Install Firacode font through Homebrew
+  homebrew_cask:
+    name: font-fira-code

--- a/playbooks/roles/brew-cask/tasks/main.yml
+++ b/playbooks/roles/brew-cask/tasks/main.yml
@@ -24,6 +24,9 @@
 - import_tasks: visualstudiocode.yml
   when: js_homebrewcask_visualstudiocode_enabled
 
+- import_tasks: fontfiracode.yml
+  when: js_homebrewcask_fontfiracode_enabled
+
 - import_tasks: gpgsuite.yml
   when: js_homebrewcask_gpgsuite_enabled
 


### PR DESCRIPTION
Added the options in the var files and main.yml file for the Ansible jobs to import a new **fontfiracode.yml** file. This playbook task will tap the required homebrew repository and then install the FiraCode font based on a the flag or choice made by the user. This can be expanded to install other fonts in the `home-brew/cask-fonts` repository.